### PR TITLE
chore: Declare GameInfo as interface

### DIFF
--- a/position-node/src/interfaces/workflows.ts
+++ b/position-node/src/interfaces/workflows.ts
@@ -1,18 +1,18 @@
 import { Workflow } from '@temporalio/workflow';
 
-export class GameInfo {
-  anchorX = 0;
-  anchorY= 0;
-  ballX = 0;
-  ballY = 0;
-  length = 0;
-  width = 0;
-  height = 0;
-  angle = 0.0;
-  angleAccel = 0.0;
-  angleVelocity = 0.0;
-  dt = 0.0;
-  speed = 0;
+export interface GameInfo {
+  anchorX: number;
+  anchorY: number;
+  ballX: number;
+  ballY: number;
+  length: number;
+  width: number;
+  height: number;
+  angle: number;
+  angleAccel: number;
+  angleVelocity: number;
+  dt: number;
+  speed: number;
 }
 
 export interface Pendulum extends Workflow {

--- a/position-node/src/worker.ts
+++ b/position-node/src/worker.ts
@@ -1,13 +1,8 @@
 import { Worker } from '@temporalio/worker';
 
 async function run() {
-  // Worker connects to localhost by default and uses console error for logging.
-  // Customize the Worker by passing more options to create().
-  // create() tries to connect to the server and will throw if a connection could not be established.
-  // You may create multiple Workers in a single process in order to poll on multiple task queues.
-  // In order to configure the server connection parameters and other global options,
-  // use the Core.install() method to configure the Rust Core SDK singleton.
   const worker = await Worker.create({
+    // FIXME: workDir with undefined activities is not working
     workflowsPath: `${__dirname}/workflows`,
     nodeModulesPath: `${__dirname}/../node_modules`,
     taskQueue: 'PendulumNode'

--- a/position-node/src/workflows/PositionWorkflow.ts
+++ b/position-node/src/workflows/PositionWorkflow.ts
@@ -2,16 +2,11 @@ import { Trigger } from '@temporalio/workflow';
 import { Pendulum, GameInfo } from '../interfaces/workflows';
 
 let gameInfo: GameInfo;
-let trigger: Trigger<void>;
-let exited: boolean;
+let exited: Trigger<void>;
 
 async function main(info: GameInfo): Promise<void> {
   gameInfo = info;
-  // FIXME: It should suffice to await only the exit trigger,
-  // but the other signals were not being processed.
-  while (!exited) {
-    await (trigger = new Trigger<void>())
-  }
+  await (exited = new Trigger<void>())
 }
 
 function getGameInfo(): GameInfo {
@@ -20,14 +15,12 @@ function getGameInfo(): GameInfo {
 
 function updateGameInfo(info: GameInfo): void {
   gameInfo = info;
-  trigger.resolve();
 }
 
 function setupMove(): void {
   gameInfo.angleAccel = -9.81 / gameInfo.length * Math.sin(gameInfo.angle);
   gameInfo.angleVelocity += gameInfo.angleAccel * gameInfo.dt;
   gameInfo.angle += gameInfo.angleVelocity * gameInfo.dt;
-  trigger.resolve();
 }
 
 function move(): void {
@@ -35,12 +28,10 @@ function move(): void {
   gameInfo.anchorY = gameInfo.height / 4;
   gameInfo.ballX = Math.floor(gameInfo.anchorX + Math.sin(gameInfo.angle) * gameInfo.length);
   gameInfo.ballY = Math.floor(gameInfo.anchorY + Math.cos(gameInfo.angle) * gameInfo.length);
-  trigger.resolve();
 }
 
 function exit(): void {
-  exited = true;
-  trigger.resolve();
+  exited.resolve();
 }
 
 export const workflow: Pendulum = {

--- a/position-node/src/workflows/PositionWorkflow.ts
+++ b/position-node/src/workflows/PositionWorkflow.ts
@@ -1,12 +1,13 @@
 import { Trigger } from '@temporalio/workflow';
 import { Pendulum, GameInfo } from '../interfaces/workflows';
 
+const exited = new Trigger<void>();
+
 let gameInfo: GameInfo;
-let exited: Trigger<void>;
 
 async function main(info: GameInfo): Promise<void> {
   gameInfo = info;
-  await (exited = new Trigger<void>())
+  await exited;
 }
 
 function getGameInfo(): GameInfo {

--- a/position-node/src/workflows/PositionWorkflow.ts
+++ b/position-node/src/workflows/PositionWorkflow.ts
@@ -7,6 +7,8 @@ let exited: boolean;
 
 async function main(info: GameInfo): Promise<void> {
   gameInfo = info;
+  // FIXME: It should suffice to await only the exit trigger,
+  // but the other signals were not being processed.
   while (!exited) {
     await (trigger = new Trigger<void>())
   }


### PR DESCRIPTION
## What was changed

* Declare GameInfo as interface with plain JS objects instead of as a class
* Use trigger only for exit

NOTE: AFAICT, the trigger must instantiated in the main function. Something to do with cancellation scope?

## Why?

_Classes shouldn't be used as arguments and return types because they are not reconstructed when parsing them from JSON (which is used in the default data converter)._