### PR TITLE
flatten out testing logic to make tests more readable

### DIFF
--- a/position-node/src/workflows.test.ts
+++ b/position-node/src/workflows.test.ts
@@ -27,6 +27,8 @@ const gameInfo: GameInfo = Object.freeze({
   speed: 0,
 });
 
+const initInfo = { ...gameInfo, anchorX: 1 };
+
 beforeAll(async () => {
   // Use console.log instead of console.error to avoid red output
   // Filter INFO log messages for clearer test output

--- a/position-node/src/workflows.test.ts
+++ b/position-node/src/workflows.test.ts
@@ -1,4 +1,5 @@
 import { WorkflowHandle } from '@temporalio/client';
+import { WorkflowNotFoundError } from '@temporalio/common';
 import { TestWorkflowEnvironment } from '@temporalio/testing';
 import { Worker, Runtime, DefaultLogger, LogEntry } from '@temporalio/worker';
 import { exitSignal, GameInfo, getGameInfoQuery, pendulum, updateGameInfoSignal } from './workflows';
@@ -60,8 +61,7 @@ beforeEach(async () => {
 
 afterEach(async() => {
   await handle.terminate().catch(err => {
-    // TODO: make TypeScript SDK export WorkflowNotFoundError
-    if (err?.name === 'WorkflowNotFoundError') {
+    if (err instanceof WorkflowNotFoundError) {
       return;
     }
 

--- a/position-node/src/workflows.test.ts
+++ b/position-node/src/workflows.test.ts
@@ -55,7 +55,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   handle = await testEnv.workflowClient.start(pendulum, {
-    args: [{ ...gameInfo, anchorX: 1 }],
+    args: [initInfo],
     workflowId: uuid4(),
     taskQueue,
   });

--- a/position-node/src/workflows.test.ts
+++ b/position-node/src/workflows.test.ts
@@ -82,7 +82,6 @@ test('pendulum exitSignal', async () => {
 });
 
 test('pendulum getGameInfoQuery', async () => {
-  const info = { ...gameInfo, anchorX: 1 };
   const queryResult = await handle.query(getGameInfoQuery);
   expect(queryResult).toEqual(info);
 });

--- a/position-node/src/workflows.test.ts
+++ b/position-node/src/workflows.test.ts
@@ -83,7 +83,7 @@ test('pendulum exitSignal', async () => {
 
 test('pendulum getGameInfoQuery', async () => {
   const queryResult = await handle.query(getGameInfoQuery);
-  expect(queryResult).toEqual(info);
+  expect(queryResult).toEqual(initInfo);
 });
 
 test('pendulum updateGameInfoSignal', async () => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Current code uses `runUntil()`, [which makes it a bit tricky to test queries and signals](https://github.com/temporalio/documentation/pull/1252). It could also benefit from using Jest hooks rather than helper functions.

Also, why are we using Jest here? I'm a bit wary of recommending users use Jest.

## Why?

I haven't been able to repro https://github.com/temporalio/sdk-typescript/issues/728, but I suspect that `runUntil()` may have something to do with it. @joebowbeer can you try out these tests and see if you're still experiencing the issue you reported in https://github.com/temporalio/sdk-typescript/issues/728 ?

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
